### PR TITLE
replace deprecated ifloor(x) with floor(Int, x)

### DIFF
--- a/src/lineplot.jl
+++ b/src/lineplot.jl
@@ -26,8 +26,8 @@ function lineplot(x::AbstractArray, y::AbstractArray)
     y = y / maximum(y)
 
     # Snap data points to a grid
-    xi = ifloor(x * (res_x - 1)) .+ 1
-    yi = ifloor(y * (res_y - 1)) .+ 1
+    xi = floor(Int, x * (res_x - 1)) .+ 1
+    yi = floor(Int, y * (res_y - 1)) .+ 1
 
     # Compute slope and non-empty points
     dy = diff([y, 2 * y[end] - y[end - 1]]) ./

--- a/src/scatterplot.jl
+++ b/src/scatterplot.jl
@@ -21,8 +21,8 @@ function scatterplot(x::AbstractArray, y::AbstractArray; sym::Char = '^')
     y = y / maximum(y)
 
     # Snap data points to a grid
-    xi = ifloor(x * (res_x - 1)) .+ 1
-    yi = ifloor(y * (res_y - 1)) .+ 1
+    xi = floor(Int, x * (res_x - 1)) .+ 1
+    yi = floor(Int, y * (res_y - 1)) .+ 1
 
     # Is there a point at location (i, j)?
     A = zeros(res_y, res_x)


### PR DESCRIPTION
ifloor is deprecated in 0.4. does this need to be wrapped in a version check to support both 0.3 and 0.4?